### PR TITLE
[Fixed][Data Table]Lost Style

### DIFF
--- a/src/app/public-share/component/data-table/data-table.component.scss
+++ b/src/app/public-share/component/data-table/data-table.component.scss
@@ -159,3 +159,7 @@ mat-row.expand-row-cursor {
     }
   }
 }
+
+.hidePaginator {
+  display: none;
+}


### PR DESCRIPTION
Can't hide paginator.

Root Cause:
Lost the hidden style.

Solved:
Add the hidden style.